### PR TITLE
[89] - Corrige encriptação da senha do usuário

### DIFF
--- a/src/main/java/com/qualfacul/hades/login/LoginInfo.java
+++ b/src/main/java/com/qualfacul/hades/login/LoginInfo.java
@@ -9,6 +9,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 
@@ -49,12 +50,13 @@ public class LoginInfo {
 		this.password = password;
 		this.loginOrigin = loginOrigin;
 	}
-	
+
 	@PrePersist
-	public void hashPassword(){
+	@PreUpdate
+	private void hashPassword() {
 		this.password = password != null ? BCrypt.hashpw(password, BCrypt.gensalt()) : password;
 	}
-	
+
 	public Long getId() {
 		return id;
 	}
@@ -94,8 +96,8 @@ public class LoginInfo {
 	public void setToken(String token) {
 		this.token = token;
 	}
-	
-	public boolean isFromFacebook(){
+
+	public boolean isFromFacebook() {
 		return FACEBOOK.equals(this.loginOrigin);
 	}
 }


### PR DESCRIPTION
## TEST

- [x] Realizar um novo cadastro com o FACEBOOK, logo em seguida se cadastrar normalmente com o mesmo email, a senha deve ser salva encriptada
- [x] Realizar um novo cadastro direto, a senha deve ser salva encriptada