### PR TITLE
[I43] - Erro ao enviar email de recuperação corrigido

### DIFF
--- a/src/main/java/com/qualfacul/hades/mail/SmtpEmailSender.java
+++ b/src/main/java/com/qualfacul/hades/mail/SmtpEmailSender.java
@@ -15,6 +15,9 @@ public class SmtpEmailSender {
 	private static final Logger LOGGER = LoggerFactory.getLogger(SmtpEmailSender.class);
 	private static final String UTF_8_CHARSET = "UTF-8";
 
+	@Value("${email.debug}")
+	private boolean emailDebug;
+	
 	@Value("${email.hostname}")
 	private String hostName;
 
@@ -56,9 +59,9 @@ public class SmtpEmailSender {
 	}
 	
 	public class Sender {
-		
 		public void send() {
 			HtmlEmail htmlEmail = new HtmlEmail();
+			htmlEmail.setDebug(emailDebug);
 			htmlEmail.setSSLOnConnect(true);
 			htmlEmail.setHostName(hostName);
 			htmlEmail.setSslSmtpPort(port);

--- a/src/main/resources/application.properties.sample
+++ b/src/main/resources/application.properties.sample
@@ -10,6 +10,7 @@ db.username=root
 db.password=
 db.driver=com.mysql.jdbc.Driver
 
+email.debug=false
 email.hostname=
 email.port=
 email.name=


### PR DESCRIPTION
Corrige issue #43

-Incluida variável para exibir log do envio de e-mail no application.properties.

Alterar o `email.hostname` para `smtp.yandex.com`