### PR TITLE
[I58] - Endpoints para criação de LoginInfo para a faculdade

### DIFF
--- a/src/main/java/com/qualfacul/hades/annotation/OnlyAdmin.java
+++ b/src/main/java/com/qualfacul/hades/annotation/OnlyAdmin.java
@@ -1,0 +1,13 @@
+package com.qualfacul.hades.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface OnlyAdmin {
+}

--- a/src/main/java/com/qualfacul/hades/college/College.java
+++ b/src/main/java/com/qualfacul/hades/college/College.java
@@ -1,5 +1,7 @@
 package com.qualfacul.hades.college;
 
+import static javax.persistence.CascadeType.ALL;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -10,7 +12,9 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 
@@ -19,6 +23,7 @@ import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.IndexedEmbedded;
 
+import com.qualfacul.hades.login.LoginInfo;
 import com.qualfacul.hades.user.User;
 
 @Indexed
@@ -57,6 +62,10 @@ public class College {
 	@Column(name = "site", length = 60, nullable = true)
 	@Boost(0.7f)
 	private String site;
+	
+	@OneToOne(cascade = ALL)
+	@JoinColumn(name = "login_info_id", referencedColumnName = "id", nullable = true)
+	private LoginInfo loginInfo;
 
 	@IndexedEmbedded
 	@OneToMany(cascade = CascadeType.MERGE, mappedBy = "college")
@@ -127,6 +136,18 @@ public class College {
 
 	public void setSite(String site) {
 		this.site = site;
+	}
+
+	public LoginInfo getLoginInfo() {
+		return loginInfo;
+	}
+
+	public void setLoginInfo(LoginInfo loginInfo) {
+		this.loginInfo = loginInfo;
+	}
+
+	public void setAddresses(List<CollegeAddress> addresses) {
+		this.addresses = addresses;
 	}
 
 	public void setAdresses(List<CollegeAddress> adresses) {

--- a/src/main/java/com/qualfacul/hades/college/College.java
+++ b/src/main/java/com/qualfacul/hades/college/College.java
@@ -25,6 +25,8 @@ import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.IndexedEmbedded;
 
 import com.qualfacul.hades.login.LoginInfo;
+import com.qualfacul.hades.login.LoginInfoRepository;
+import com.qualfacul.hades.login.LoginOrigin;
 import com.qualfacul.hades.user.User;
 
 @Indexed
@@ -172,6 +174,18 @@ public class College {
 		return addresses.stream()
 				 .flatMap(address -> address.getUserCollegeAddress().stream())
 				 .anyMatch(userCollegeAddress -> userCollegeAddress.getId().getUser() == student);
+	}
+	
+	public void createLogin(CollegeRepository collegeRepository, String password) {
+	    this.loginInfo = new LoginInfo(this.cnpj, password, LoginOrigin.COLLEGE);
+	    collegeRepository.save(this);
+	}
+	
+	public void removeLogin(LoginInfoRepository loginInfoRepository, CollegeRepository collegeRepository) {
+		LoginInfo loginInfo = this.loginInfo;
+		this.loginInfo = null;
+	    collegeRepository.save(this);
+	    loginInfoRepository.delete(loginInfo);
 	}
 	
 	@Override

--- a/src/main/java/com/qualfacul/hades/college/College.java
+++ b/src/main/java/com/qualfacul/hades/college/College.java
@@ -5,6 +5,7 @@ import static javax.persistence.CascadeType.ALL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -138,8 +139,11 @@ public class College {
 		this.site = site;
 	}
 
-	public LoginInfo getLoginInfo() {
-		return loginInfo;
+	public Optional<LoginInfo> getLoginInfo() {
+		if (loginInfo == null){
+			return Optional.empty();
+		}
+		return Optional.of(loginInfo);
 	}
 
 	public void setLoginInfo(LoginInfo loginInfo) {
@@ -148,10 +152,6 @@ public class College {
 
 	public void setAddresses(List<CollegeAddress> addresses) {
 		this.addresses = addresses;
-	}
-
-	public void setAdresses(List<CollegeAddress> adresses) {
-		this.addresses = adresses;
 	}
 
 	public void setGrades(List<CollegeGrade> grades) {

--- a/src/main/java/com/qualfacul/hades/college/College.java
+++ b/src/main/java/com/qualfacul/hades/college/College.java
@@ -142,14 +142,7 @@ public class College {
 	}
 
 	public Optional<LoginInfo> getLoginInfo() {
-		if (loginInfo == null){
-			return Optional.empty();
-		}
-		return Optional.of(loginInfo);
-	}
-
-	public void setLoginInfo(LoginInfo loginInfo) {
-		this.loginInfo = loginInfo;
+		return Optional.ofNullable(loginInfo);
 	}
 
 	public void setAddresses(List<CollegeAddress> addresses) {
@@ -184,8 +177,8 @@ public class College {
 	public void removeLogin(LoginInfoRepository loginInfoRepository, CollegeRepository collegeRepository) {
 		LoginInfo loginInfo = this.loginInfo;
 		this.loginInfo = null;
-	    collegeRepository.save(this);
-	    loginInfoRepository.delete(loginInfo);
+		collegeRepository.save(this);
+		loginInfoRepository.delete(loginInfo);
 	}
 	
 	@Override

--- a/src/main/java/com/qualfacul/hades/college/CollegeController.java
+++ b/src/main/java/com/qualfacul/hades/college/CollegeController.java
@@ -123,7 +123,7 @@ public class CollegeController {
 	}
 	
 	@OnlyAdmin
-	@Post("/colleges/{collegeId}/logininfo")
+	@Post("/colleges/{collegeId}/login")
 	public void createLoginInfo(@PathVariable Long collegeId, @Valid @RequestBody CollegeLoginDTO dto){
 		College college = collegeRepository.findById(collegeId).orElseThrow(CollegeNotFoundException::new);
 		if (college.getLoginInfo() != null){
@@ -134,13 +134,13 @@ public class CollegeController {
 	}
 	
 	@OnlyAdmin
-	@Delete("/colleges/{collegeId}/logininfo")
+	@Delete("/colleges/{collegeId}/login")
 	public void deleteLoginInfo(@PathVariable Long collegeId){
 		College college = collegeRepository.findById(collegeId).orElseThrow(CollegeNotFoundException::new);
-		if (college.getLoginInfo() == null){
+		if (!college.getLoginInfo().isPresent()){
 			throw new CollegeWithoutLoginAccessException();
 		}
-		LoginInfo loginInfo = college.getLoginInfo();
+		LoginInfo loginInfo = college.getLoginInfo().get();
 		loginInfoRepository.delete(loginInfo);
 		college.setLoginInfo(null);
 		collegeRepository.save(college);

--- a/src/main/java/com/qualfacul/hades/college/CollegeLoginDTO.java
+++ b/src/main/java/com/qualfacul/hades/college/CollegeLoginDTO.java
@@ -1,0 +1,26 @@
+package com.qualfacul.hades.college;
+
+import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.constraints.NotEmpty;
+
+public class CollegeLoginDTO {
+	@NotEmpty(message = "hades.user.empty.password")
+	@Length(min = 6, message = "hades.user.invalid.password")
+	private String password;
+	
+	@Deprecated
+	public CollegeLoginDTO(){
+	}
+	
+	public CollegeLoginDTO(String password){
+		this.password = password;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+}

--- a/src/main/java/com/qualfacul/hades/college/CollegeLoginDTO.java
+++ b/src/main/java/com/qualfacul/hades/college/CollegeLoginDTO.java
@@ -4,18 +4,11 @@ import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.NotEmpty;
 
 public class CollegeLoginDTO {
+	
 	@NotEmpty(message = "hades.user.empty.password")
 	@Length(min = 6, message = "hades.user.invalid.password")
 	private String password;
 	
-	@Deprecated
-	public CollegeLoginDTO(){
-	}
-	
-	public CollegeLoginDTO(String password){
-		this.password = password;
-	}
-
 	public String getPassword() {
 		return password;
 	}

--- a/src/main/java/com/qualfacul/hades/exceptions/CollegeAlreadyHaveLoginException.java
+++ b/src/main/java/com/qualfacul/hades/exceptions/CollegeAlreadyHaveLoginException.java
@@ -1,0 +1,10 @@
+package com.qualfacul.hades.exceptions;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = BAD_REQUEST, reason = "This college already have a login")
+public class CollegeAlreadyHaveLoginException extends RuntimeException {
+	private static final long serialVersionUID = 1L;
+}

--- a/src/main/java/com/qualfacul/hades/exceptions/CollegeWithoutLoginAccessException.java
+++ b/src/main/java/com/qualfacul/hades/exceptions/CollegeWithoutLoginAccessException.java
@@ -1,0 +1,10 @@
+package com.qualfacul.hades.exceptions;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = NOT_FOUND, reason = "This college doesn't have a login to be deleted")
+public class CollegeWithoutLoginAccessException extends RuntimeException {
+	private static final long serialVersionUID = 1L;
+}

--- a/src/main/java/com/qualfacul/hades/exceptions/OnlyAdminsCanAccessException.java
+++ b/src/main/java/com/qualfacul/hades/exceptions/OnlyAdminsCanAccessException.java
@@ -1,0 +1,9 @@
+package com.qualfacul.hades.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.FORBIDDEN, reason = "This operation can only be user by administrators")
+public class OnlyAdminsCanAccessException extends RuntimeException {
+	private static final long serialVersionUID = 1L;
+}

--- a/src/main/java/com/qualfacul/hades/interceptor/LoggedUserValidatorInterceptor.java
+++ b/src/main/java/com/qualfacul/hades/interceptor/LoggedUserValidatorInterceptor.java
@@ -7,8 +7,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
+import com.qualfacul.hades.annotation.OnlyAdmin;
 import com.qualfacul.hades.annotation.OnlyStudents;
 import com.qualfacul.hades.annotation.WebComponent;
+import com.qualfacul.hades.exceptions.OnlyAdminsCanAccessException;
 import com.qualfacul.hades.exceptions.OnlyStudentsCanAccessException;
 import com.qualfacul.hades.login.LoggedUserManager;
 
@@ -32,6 +34,13 @@ public class LoggedUserValidatorInterceptor extends HandlerInterceptorAdapter{
 			
 			if (onlyStudentsCanPass && isNotUser) {
 				throw new OnlyStudentsCanAccessException();
+			}
+			
+			boolean onlyAdminCanPass = handlerMethod.getMethod().isAnnotationPresent(OnlyAdmin.class);
+			boolean isNotAdmin = loggedUserManager.getLoginInfo() != null && !loggedUserManager.getLoginInfo().isAdmin();
+			
+			if (onlyAdminCanPass && isNotAdmin){
+				throw new OnlyAdminsCanAccessException();
 			}
 		}
 		return true;

--- a/src/main/java/com/qualfacul/hades/login/LoginInfo.java
+++ b/src/main/java/com/qualfacul/hades/login/LoginInfo.java
@@ -106,6 +106,11 @@ public class LoginInfo {
 		}
 		return true;
 	}
+	
+	public boolean isAdmin(){
+		return ADMIN == loginOrigin;
+	}
+	
 	public boolean isFromFacebook() {
 		return FACEBOOK == loginOrigin;
 	}

--- a/src/main/java/com/qualfacul/hades/login/LoginInfoRepository.java
+++ b/src/main/java/com/qualfacul/hades/login/LoginInfoRepository.java
@@ -10,5 +10,7 @@ public interface LoginInfoRepository {
 	LoginInfo save(LoginInfo loginInfo);
 
 	Optional<LoginInfo> findByLogin(String login);
+	
+	void delete(LoginInfo loginInfo);
 
 }

--- a/src/test/java/com/qualfacul/hades/college/CollegeToCollegeDTOConverterTest.java
+++ b/src/test/java/com/qualfacul/hades/college/CollegeToCollegeDTOConverterTest.java
@@ -61,7 +61,7 @@ public class CollegeToCollegeDTOConverterTest {
 		
 		UserCollegeAddress someUserCollegeAddress = new UserCollegeAddress(anyId, "");
 		
-		from.setAdresses(asList(collegeAddress1, collegeAddress2));
+		from.setAddresses(asList(collegeAddress1, collegeAddress2));
 		from.setGrades(asList(grade1, grade2, grade3, grade4));
 		
 		Integer coursesCount1 = 2;

--- a/src/test/java/com/qualfacul/hades/interceptor/LoggedUserValidatorInterceptorTest.java
+++ b/src/test/java/com/qualfacul/hades/interceptor/LoggedUserValidatorInterceptorTest.java
@@ -41,6 +41,7 @@ public class LoggedUserValidatorInterceptorTest {
 	@Test
 	public void shouldAccessWhenLoggedUserIsAUser() throws Exception {
 		when(loggedUserManager.getLoginInfo().isUser()).thenReturn(true);
+		when(loggedUserManager.getLoginInfo().isAdmin()).thenReturn(false);
 		
 		Method method = stream(ConversationController.class.getMethods())
 						.filter(m -> m.isAnnotationPresent(OnlyStudents.class))

--- a/src/test/java/com/qualfacul/hades/interceptor/LoggedUserValidatorInterceptorTest.java
+++ b/src/test/java/com/qualfacul/hades/interceptor/LoggedUserValidatorInterceptorTest.java
@@ -16,8 +16,11 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.method.HandlerMethod;
 
+import com.qualfacul.hades.annotation.OnlyAdmin;
 import com.qualfacul.hades.annotation.OnlyStudents;
+import com.qualfacul.hades.college.CollegeController;
 import com.qualfacul.hades.conversation.ConversationController;
+import com.qualfacul.hades.exceptions.OnlyAdminsCanAccessException;
 import com.qualfacul.hades.exceptions.OnlyStudentsCanAccessException;
 import com.qualfacul.hades.login.LoggedUserManager;
 
@@ -53,12 +56,26 @@ public class LoggedUserValidatorInterceptorTest {
 	@Test(expected = OnlyStudentsCanAccessException.class)
 	public void shouldNotAccessWhenLoggedUserIsNotAStudent() throws Exception {
 		when(loggedUserManager.getLoginInfo().isUser()).thenReturn(false);
+		when(loggedUserManager.getLoginInfo().isAdmin()).thenReturn(false);
 		
 		Method method = stream(ConversationController.class.getMethods())
 						.filter(m -> m.isAnnotationPresent(OnlyStudents.class))
 						.findFirst().get();
 		
 		HandlerMethod handler = new HandlerMethod(ConversationController.class, method);
+		
+		subject.preHandle(request, response, handler);
+	}
+	
+	@Test(expected = OnlyAdminsCanAccessException.class)
+	public void shouldNotAccessWhenLoggedUserIsNotAnAdmin() throws Exception {
+		when(loggedUserManager.getLoginInfo().isUser()).thenReturn(false);
+		
+		Method method = stream(CollegeController.class.getMethods())
+						.filter(m -> m.isAnnotationPresent(OnlyAdmin.class))
+						.findFirst().get();
+		
+		HandlerMethod handler = new HandlerMethod(CollegeController.class, method);
 		
 		subject.preHandle(request, response, handler);
 	}


### PR DESCRIPTION
Agora, logins cujo `LoginOrigin` cadastrado é `ADMIN` tem acesso ao endpoint abaixo:

- `/colleges/{collegeId}/logininfo`: Caso a requisição seja `POST`, cria um login com a senha informada no banco de dados. Caso seja `DELETE`, exclui o login da faculdade do sistema.

O merge com a branch `I48` foi feito pois commitei errado nela, e tive que passar para essa.