### PR TITLE
[I62] - Endpoints para criação e exclusão de administradores criado

### DIFF
--- a/src/main/java/com/qualfacul/hades/admin/AdminController.java
+++ b/src/main/java/com/qualfacul/hades/admin/AdminController.java
@@ -5,36 +5,54 @@ import static org.springframework.http.HttpStatus.CREATED;
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.qualfacul.hades.annotation.Delete;
+import com.qualfacul.hades.annotation.OnlyAdmin;
 import com.qualfacul.hades.annotation.Post;
 import com.qualfacul.hades.configuration.security.TokenAuthenticationService;
+import com.qualfacul.hades.exceptions.AdminCannotDeleteHimselfException;
+import com.qualfacul.hades.exceptions.AdminNotFoundException;
+import com.qualfacul.hades.login.LoggedUserManager;
 import com.qualfacul.hades.login.LoginInfo;
 import com.qualfacul.hades.login.LoginInfoDTO;
 import com.qualfacul.hades.login.LoginOrigin;
 
 @RestController
 public class AdminController {
-	
+
 	@Autowired
 	private AdminRepository adminRepository;
 
 	@Autowired
 	private TokenAuthenticationService tokenService;
 
-	@Transactional
-	@Post(value = "/admin/register", responseStatus = CREATED)
-	public LoginInfoDTO register(@Valid @RequestBody AdminDTO adminDTO) {
+	@Autowired
+	private LoggedUserManager loggedUserManager;
+
+	@OnlyAdmin
+	@Post(value = "/admin", responseStatus = CREATED)
+	public LoginInfoDTO createAdmin(@Valid @RequestBody AdminDTO adminDTO) {
 		LoginInfo loginInfo = new LoginInfo(adminDTO.getEmail(), adminDTO.getPassword(), LoginOrigin.ADMIN);
 		Admin admin = new Admin(adminDTO.getName(), adminDTO.getEmail());
 		admin.setLoginInfo(loginInfo);
-		
+
 		adminRepository.save(admin);
-		
+
 		tokenService.createTokenFor(loginInfo);
 
 		return new LoginInfoDTO().from(loginInfo);
+	}
+
+	@OnlyAdmin
+	@Delete(value = "/admin/{adminId}")
+	public void deleteAdmin(@PathVariable Long adminId) {
+		Admin admin = adminRepository.findById(adminId).orElseThrow(AdminNotFoundException::new);
+		if (loggedUserManager.getLoginInfo().getId() == admin.getLoginInfo().getId()) {
+			throw new AdminCannotDeleteHimselfException();
+		}
+		adminRepository.delete(admin);
 	}
 }

--- a/src/main/java/com/qualfacul/hades/admin/AdminRepository.java
+++ b/src/main/java/com/qualfacul/hades/admin/AdminRepository.java
@@ -1,10 +1,16 @@
 package com.qualfacul.hades.admin;
 
+import java.util.Optional;
+
 import org.springframework.data.repository.RepositoryDefinition;
 
 @RepositoryDefinition(domainClass = Admin.class, idClass = Long.class)
 public interface AdminRepository {
+	
+	Optional<Admin> findById(long id);
 
 	Admin save(Admin admin);
+	
+	void delete(Admin admin);
 
 }

--- a/src/main/java/com/qualfacul/hades/exceptions/AdminCannotDeleteHimselfException.java
+++ b/src/main/java/com/qualfacul/hades/exceptions/AdminCannotDeleteHimselfException.java
@@ -1,0 +1,10 @@
+package com.qualfacul.hades.exceptions;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = NOT_FOUND, reason = "You are not allowed to delete your own account")
+public class AdminCannotDeleteHimselfException extends RuntimeException {
+	private static final long serialVersionUID = 1L;
+}

--- a/src/main/java/com/qualfacul/hades/exceptions/AdminNotFoundException.java
+++ b/src/main/java/com/qualfacul/hades/exceptions/AdminNotFoundException.java
@@ -1,0 +1,10 @@
+package com.qualfacul.hades.exceptions;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = NOT_FOUND, reason = "Admin not found")
+public class AdminNotFoundException extends RuntimeException {
+	private static final long serialVersionUID = 1L;
+}


### PR DESCRIPTION
Os seguintes endpoints foram criados:
- `/admin`: Recebe a solicitação via `POST`, e cria o `administrador` com os dados informados;
- `/admin/{adminId}`: Recebe a solicitação via `DELETE` e exclui o `administrador` informado. O usuário que solicita a exclusão não pode ser o usuário a ser deletado. Isso garante que exista pelo menos um administrador no banco de dados.
